### PR TITLE
`socket.error` unit testing is flaky

### DIFF
--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -1,3 +1,5 @@
+import ddt
+import errno
 import socket
 
 from unittest import TestCase
@@ -11,6 +13,21 @@ from hastexo.tasks import (LaunchStackTask, CheckStudentProgressTask,
 from celery.exceptions import SoftTimeLimitExceeded
 
 
+RETRY_SOCKET_ERRNOS = [
+    errno.EAGAIN,
+    errno.ENETDOWN,
+    errno.ENETUNREACH,
+    errno.ENETRESET,
+    errno.ECONNABORTED,
+    errno.ECONNRESET,
+    errno.ENOTCONN,
+    errno.ECONNREFUSED,
+    errno.EHOSTDOWN,
+    errno.EHOSTUNREACH
+]
+
+
+@ddt.ddt
 class TestHastexoTasks(TestCase):
     def get_ssh_client_mock(self):
         return self.mocks["paramiko"].SSHClient.return_value
@@ -698,7 +715,8 @@ class TestHastexoTasks(TestCase):
         # Assertions
         self.assertEqual(res["status"], "CREATE_COMPLETE")
 
-    def test_socketerror_does_not_constitute_verify_failure(self):
+    @ddt.data(*RETRY_SOCKET_ERRNOS)
+    def test_some_socket_errors_do_not_constitute_verify_failure(self, errno):
         # Setup
         provider = self.mock_providers[0]
         provider.get_stack.side_effect = [
@@ -706,7 +724,7 @@ class TestHastexoTasks(TestCase):
         ]
         ssh = self.get_ssh_client_mock()
         ssh.connect.side_effect = [
-            socket.error,
+            EnvironmentError(errno, ''),
             True
         ]
         self.update_stack({
@@ -719,6 +737,25 @@ class TestHastexoTasks(TestCase):
 
         # Assertions
         self.assertEqual(res["status"], "CREATE_COMPLETE")
+
+    def test_other_socket_errors_constitute_verify_failure(self):
+        # Setup
+        provider = self.mock_providers[0]
+        provider.get_stack.side_effect = [
+            self.stacks["CREATE_COMPLETE"]
+        ]
+        ssh = self.get_ssh_client_mock()
+        ssh.connect.side_effect = EnvironmentError(errno.ENOTSOCK, '')
+        self.update_stack({
+            "provider": self.providers[0]["name"],
+            "status": "LAUNCH_PENDING"
+        })
+
+        # Run
+        res = LaunchStackTask().run(**self.kwargs)
+
+        # Assertions
+        self.assertEqual(res["status"], "CREATE_FAILED")
 
     def test_ssh_bombs_out(self):
         # Setup


### PR DESCRIPTION
Because of all the changes to OSError and `socket.error` between 2.7 and
3.4+, unit testing with it is a flaky affair.  However, given that:

* we still need to support Python 2.7

* from Python 2.6 until Python 3.3 `socket.error` is a subclass of
IOError, which in itself subclasses `EnvironmentError`, which implements
`errno`,

* from Python 3.3 onwards socket.error is an alias for OSError, of which
`EnvironmentError` is an alias, which also implements `errno`,

* we only care about some `errno`s anyway,

we handle `socket.error` via its common parent denominator of
`EnvironmentError`.